### PR TITLE
3.2.8.7

### DIFF
--- a/manifests/a/ASA Tools/3.0.0/manifest.json
+++ b/manifests/a/ASA Tools/3.0.0/manifest.json
@@ -5,7 +5,7 @@
         "Major": "3",
         "Minor": "2",
         "Patch": "8",
-        "Build": "5"
+        "Build": "7"
     },
     "Author": "Gerald Hitz (photon)",
     "Homepage": "",
@@ -33,9 +33,9 @@
         "AltScreenshotURL": "https://user-images.githubusercontent.com/14548927/277363713-5b8b6940-2fb1-4c91-9dcc-ca5618206fa0.png"
     },
     "Installer": {
-        "URL": "https://github.com/photon1503/NINA.Photon.Plugin.ASA/releases/download/3.2.8.5/NINA.Photon.Plugin.ASA.3.2.8.5.zip",
+        "URL": "https://github.com/photon1503/NINA.Photon.Plugin.ASA/releases/download/3.2.8.7/NINA.Photon.Plugin.ASA.3.2.8.7.zip",
         "Type": "ARCHIVE",
-        "Checksum": "F48BBA4B130028F3F2924512D23E5DA5526048184452FBBB2C3A151B9C08D87B",
+        "Checksum": "38D8E85B3C0EEF67EA7366A28DA9CBFFBB5AF22B165468C3726CECF51044A446",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
- Fixed an issue where AutoGrid builds could still use legacy azimuth sweep immediately after selecting ASA Band Path.

- Removed obsolete **Legacy Azimuth Sweep** from the AutoGrid path-order UI 

- For **AutoGrid + ASA Band Path**, sync placement now follows band/side boundaries instead of interval-based insertion. Implemented ASA Sequence-style per-block sequence: **Ref → Sync → Ref → band points**.
  - Updated sync/reference defaults to:
    - `Sync East/West = Alt 60°, Az 90° / 270°`
    - `Ref East/West = Alt 30°, Az 90° / 270°`
  - Added migration for old installs where sync/reference values were stored as all zeros: UI now auto-populates and persists current defaults.

- Restricted sync/reference controls and sync insertion behavior to **AutoGrid** builds only.
  - Golden Spiral builds now hide sync/reference options and do not insert sync points.

- Added new MLPT option **Pre-balance** to control the initial far-end slew before the first planned point.
  - Existing installs keep previous behavior by default: if no stored value exists, **Pre-balance** defaults to **ON**.