### PR TITLE
Update Collimation Helper for SkyWave to v2.0.2

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -4,7 +4,7 @@
     "Version": {
         "Major": "2",
         "Minor": "0",
-        "Patch": "1",
+        "Patch": "2",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -37,9 +37,9 @@
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.0.1/NINA.CollimationHelper.SkyWave.2.0.1.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.0.2/NINA.CollimationHelper.SkyWave.2.0.2.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "ede0dcb9bb7857d88fa36965dc8057668ca8bf5e1abd075d2304f900fcad6e2b",
+        "Checksum": "a4717324383444015ce3f3c74118e27cc243d6d3888701cbd9c19b37f0e21e68",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
## Summary
- Bump version from 2.0.1 to 2.0.2
- **Bug fix:** Filter wheel always selected Slot 0 (typically L filter) regardless of user selection. The filter slot index was hardcoded to 0 in capture sequences, autofocus, and filter switch commands. Now correctly looks up the filter's actual slot position from the NINA profile.

## Changelog
https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/blob/main/CHANGELOG.md

## Release
https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.0.2