### PR TITLE
Update Collimation Helper for SkyWave to v2.1.0

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -3,8 +3,8 @@
     "Identifier": "b7e3f1a2-9c4d-4e8b-a6f5-1d2c3b4a5e6f",
     "Version": {
         "Major": "2",
-        "Minor": "0",
-        "Patch": "2",
+        "Minor": "1",
+        "Patch": "0",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -30,16 +30,16 @@
         "Build": "9001"
     },
     "Descriptions": {
-        "ShortDescription": "Automated SkyWave collimation helper — 106 star presets (both hemispheres), zoomable preview, circular defocused capture & FITS integration",
+        "ShortDescription": "Automated SkyWave collimation helper — circular defocused star capture & native FITS integration",
         "LongDescription": "Collimation Helper for SkyWave automates the complete telescope collimation data-capture workflow inside N.I.N.A., producing wavefront-ready FITS images for InnovationForesight's SkyWave AI analysis:\r\n\r\n1. Select an isolated star of appropriate magnitude (auto-selected based on your optics)\r\n2. Plate-solve and center on the star (in focus)\r\n3. Switch to the target filter and optionally run autofocus\r\n4. Defocus the telescope by a configurable number of focuser steps\r\n5. Capture exposures at N positions around a circular ring pattern covering the full sensor plane\r\n6. MAX-stack sub-frames into a single FITS (each pixel keeps its maximum value)\r\n7. Save the SkyWave-ready FITS to your configured watch folder\r\n8. Return the focuser to its original position\r\n\r\nBy spreading the defocused star across the entire sensor, SkyWave can detect not just on-axis collimation errors but also field-dependent aberrations like tilt, spacing issues, and off-axis coma — something a single centered star image cannot reveal.\r\n\r\nProvides both individual sequence instructions (SkwDefocus, SkwCircularCapture, SkwIntegrateFrames) for advanced users and a single SkwCollimationRun container for one-click operation.\r\n\r\nIf you find this useful, consider buying me a coffee: https://buymeacoffee.com/joergsflow",
         "FeaturedImageURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png",
         "ScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginrun.png",
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.0.2/NINA.CollimationHelper.SkyWave.2.0.2.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.1.0/NINA.CollimationHelper.SkyWave.2.1.0.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "a4717324383444015ce3f3c74118e27cc243d6d3888701cbd9c19b37f0e21e68",
+        "Checksum": "7AC1CFD55507EE3A34998F051678710FCA6492B7635D8449D4E5F0964D39E97C",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
Update **Collimation Helper for SkyWave** from v2.0.2 to **v2.1.0**.

## What's new in this release

Focused release for southern-hemisphere observers, driven by a user bug report from Australia / New Zealand. Three bugs fixed, two features added.

### Fixed
- **"Find Best" could pick stars below the horizon.** The altitude check now enforces a 30° minimum (with automatic fallback to 20° then 10°), and returns a clear "no suitable star visible now" message if nothing passes — instead of silently returning the least-bad candidate.
- **Capture filter sometimes left on the plate-solve filter.** `SwitchFilter("Default")` was a silent no-op, so after NINA's `Center` instruction switched filters internally for plate-solving, the plugin never switched back. The target filter is now pre-resolved at the very start of the run — before any filter motion — and always used explicitly for capture.

### Changed
- **"Find Best" now prefers stars near the zenith.** Scored by `alt + transitAlt - 90`, so a star currently at 60° on its way to an 85° transit beats a star currently at 70° that will set in an hour.

### Added
- **"Use Mount" button** next to "Find Best" — reads the mount's current RA/Dec and loads it as the target, letting users slew manually (Stellarium, framing wizard, hand controller) and collimate from any point in the sky. Bypasses the preset catalog entirely when needed.
- **14 new southern winter/spring stars** (Aludra, σ Pup, α Ant, Algorab, δ TrA, ζ² Sco, η Sco, β Ara, α Tel, Kaus Meridionalis, Albaldah, α Ind, β Pav, γ Pav) closing the previous RA 16h–21h meridian-crossing gap. Catalog total is now **120 stars** covering every inhabited latitude.

## Release artifacts

- **Release:** https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.1.0
- **Full changelog:** https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/blob/main/CHANGELOG.md
- **ZIP checksum (SHA256):** `7AC1CFD55507EE3A34998F051678710FCA6492B7635D8449D4E5F0964D39E97C`
- **Manifest generated via:** `CreateManifest.ps1` from `isbeorn/nina.plugin.manifests/tools/` in CI (Windows build, .NET 8)