### PR TITLE
Update CollimationHelperForSkyWave to v2.1.1

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -4,7 +4,7 @@
     "Version": {
         "Major": "2",
         "Minor": "1",
-        "Patch": "0",
+        "Patch": "1",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -37,9 +37,9 @@
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.1.0/NINA.CollimationHelper.SkyWave.2.1.0.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.1.1/NINA.CollimationHelper.SkyWave.2.1.1.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "7AC1CFD55507EE3A34998F051678710FCA6492B7635D8449D4E5F0964D39E97C",
+        "Checksum": "042D43B1AB9BFA4890A64B8E754BFA5917AF59FED9329DCEDAE6120229F616C9",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
### Summary
Patch release of **Collimation Helper for SkyWave** (identifier `b7e3f1a2-9c4d-4e8b-a6f5-1d2c3b4a5e6f`): **v2.1.0 → v2.1.1**.

### What changed
- **Fix:** the plate-solve-failed fallback in `SkwPanelVM.RunCollimation` used to silently blind-slew after logging a quiet `Logger.Warning`. This hid mount-side ASCOM-driver epoch-reporting bugs (known 10Micron quirk) as a ~8–12 arcmin pattern offset. The fallback now fires `Notification.ShowWarning` and leaves a persistent `WARNING:` prefix in the status text so the user can see that the blind path was taken.

### Release
- Stable: https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.1.1
- Installer: `NINA.CollimationHelper.SkyWave.2.1.1.9.zip` (SHA256 `042D43B1AB9BFA4890A64B8E754BFA5917AF59FED9329DCEDAE6120229F616C9`)
- Changelog: https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/blob/main/CHANGELOG.md

Manifest generated with the official `CreateManifest.ps1` from this repo's `tools/` via CI.