### PR TITLE
Add Astro PM plugin v1.0.0.4

### DIFF
--- a/manifests/a/Astro PM/3.0.0.9001/1.0.0.2/manifest.json
+++ b/manifests/a/Astro PM/3.0.0.9001/1.0.0.2/manifest.json
@@ -1,0 +1,42 @@
+{
+    "Name": "Astro PM",
+    "Identifier": "C8F1A2B3-D4E5-6F78-9A0B-1C2D3E4F5A6B",
+    "Version": {
+        "Major": "1",
+        "Minor": "0",
+        "Patch": "0",
+        "Build": "2"
+    },
+    "Author": "Astro PM",
+    "Homepage": "https://astro-pm.com",
+    "Repository": "https://github.com/Josh-Jones-76/AstroPM.NINA.Plugin",
+    "License": "MIT",
+    "LicenseURL": "https://opensource.org/licenses/MIT",
+    "ChangelogURL": "https://github.com/Josh-Jones-76/AstroPM.NINA.Plugin/releases",
+    "Tags": [
+        "Sync",
+        "Targets",
+        "Framing",
+        "StarLog",
+        "Cloud"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "0",
+        "Patch": "0",
+        "Build": "9001"
+    },
+    "Descriptions": {
+        "ShortDescription": "Syncs imaging targets from Astro PM (Astro Project Manager) to NINA's Framing Assistant. Requires an Astro PM license.",
+        "LongDescription": "Astro PM is a cloud-based astrophotography project manager. This plugin connects NINA to your Astro PM account so you can pull imaging targets directly into NINA's Framing Assistant — no manual entry, no copy-paste mistakes.\r\n\r\nWhen you load a target, the plugin sets:\r\n- RA/Dec coordinates\r\n- Camera parameters (FL, sensor, pixel size)\r\n- Rotation angle\r\n- Mosaic panel layout (rows, columns)\r\n- Panel overlap\r\n\r\nThe plugin adds a target selector ComboBox directly into the Framing Assistant UI, plus an Options page with a filterable target list (filter by Status, Location, Scope, Camera) and a one-click Load to Framing button.\r\n\r\nRequirements:\r\n- N.I.N.A. 3.0.0.9001 or newer\r\n- Valid Astro PM license (https://astro-pm.com)",
+        "FeaturedImageURL": "https://asgastronomy.com/downloads/AstroPM-Logo-Icon-500x500.png",
+        "ScreenshotURL": "",
+        "AltScreenshotURL": ""
+    },
+    "Installer": {
+        "URL": "https://github.com/Josh-Jones-76/AstroPM.NINA.Plugin/releases/download/1.0.0.2/AstroPM.NINA.Plugin-1.0.0.2.zip",
+        "Type": "ARCHIVE",
+        "Checksum": "80BF7A27A91E6F47E839F6F0FDF1019A69026CB94512AC3B947AF16035502F87",
+        "ChecksumType": "SHA256"
+    }
+}


### PR DESCRIPTION
Initial submission for the Astro PM plugin.

Astro PM is a NINA plugin that syncs imaging targets from the Astro PM cloud project manager (https://astro-pm.com) into NINA's Framing Assistant. When a target is loaded, the plugin sets RA/Dec coordinates, camera parameters, rotation, mosaic panel layout, and panel overlap.

### Plugin
- **Name:** Astro PM
- **Version:** 1.0.0.4
- **Min N.I.N.A. version:** 3.0.0.9001
- **License:** MIT
- **Repository:** https://github.com/Josh-Jones-76/AstroPM.NINA.Plugin
- **Release:** https://github.com/Josh-Jones-76/AstroPM.NINA.Plugin/releases/tag/1.0.0.4

### Manifest path
`manifests/a/Astro PM/3.0.0.9001/1.0.0.4/manifest.json`

### Verification
- [x] Repo is public, MIT licensed
- [x] LICENSE file in repo root
- [x] Installer URL returns HTTP 200
- [x] SHA256 checksum recomputed against the published asset
- [x] FeaturedImageURL returns HTTP 200 / image/png