### PR TITLE
Update Subframes to 0.3.6 - fix name conflict and TS integration

### DIFF
--- a/manifests/s/Subframes/3.1.0/manifest.json
+++ b/manifests/s/Subframes/3.1.0/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "Major": "0",
     "Minor": "3",
-    "Patch": "3",
+    "Patch": "6",
     "Build": "0"
   },
   "Author": "Subframes.io",
@@ -35,9 +35,9 @@
     "FeaturedImageURL": ""
   },
   "Installer": {
-    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.3.3/SubframesPlugin-v0.3.3.zip",
+    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.3.6/SubframesPlugin-v0.3.6.zip",
     "Type": "ARCHIVE",
-    "Checksum": "136542fccba5d7095a31b2042f6be29628ae75d0fbaf7a379cc615d5ecde8cdb",
+    "Checksum": "115f5d4831efd9fe0f9a95fccb0a73eb3ed662f15b3c3e562f718a24c8e78f65",
     "ChecksumType": "SHA256"
   }
 }

--- a/manifests/s/Subframes/3.1.0/manifest.json
+++ b/manifests/s/Subframes/3.1.0/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "Major": "0",
     "Minor": "3",
-    "Patch": "2",
+    "Patch": "3",
     "Build": "0"
   },
   "Author": "Subframes.io",
@@ -35,9 +35,9 @@
     "FeaturedImageURL": ""
   },
   "Installer": {
-    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.3.2/SubframesPlugin-v0.3.2.zip",
+    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.3.3/SubframesPlugin-v0.3.3.zip",
     "Type": "ARCHIVE",
-    "Checksum": "ea21424baad7aafe219d72a435593b85ea37db43192dab3d47925869da890a55",
+    "Checksum": "136542fccba5d7095a31b2042f6be29628ae75d0fbaf7a379cc615d5ecde8cdb",
     "ChecksumType": "SHA256"
   }
 }


### PR DESCRIPTION
Change: Renamed _status → _sessionStatus in SetSessionStatusItem.cs, which changes the generated property from Status to SessionStatus. This eliminates the AmbiguousMatchException caused by NINA 3.3 adding a Status property to the SequenceItem base class.

All in-class references updated
ApplicationStatus.Status (NINA's type) left untouched
No XAML bindings or tests reference this property
Compatible with both NINA 3.2 and 3.3

Also fixed guard timer around getting TS preview data.