### PR TITLE
Update CollimationHelperForSkyWave to v2.2.0

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -3,8 +3,8 @@
     "Identifier": "b7e3f1a2-9c4d-4e8b-a6f5-1d2c3b4a5e6f",
     "Version": {
         "Major": "2",
-        "Minor": "1",
-        "Patch": "1",
+        "Minor": "2",
+        "Patch": "0",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -37,9 +37,9 @@
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.1.1/NINA.CollimationHelper.SkyWave.2.1.1.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.2.0/NINA.CollimationHelper.SkyWave.2.2.0.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "042D43B1AB9BFA4890A64B8E754BFA5917AF59FED9329DCEDAE6120229F616C9",
+        "Checksum": "4B03705363FBF72416A4DF9622140A5CCC10358608E974629F2EC8D5B129148C",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
### Summary
Minor release of **Collimation Helper for SkyWave** (identifier `b7e3f1a2-9c4d-4e8b-a6f5-1d2c3b4a5e6f`): **v2.1.1 → v2.2.0**.

(Previously released v2.1.2 was an internal iteration and is superseded by v2.2.0; its fixes are included.)

### What changed
Two field-reported issues addressed:

- **New "Skip solve" panel toggle** (Rick — GSO RC 16″, FOV ~17×24 arcmin): when NINA's local plate-solver can't solve the centring frame on a sparse / low-altitude target (e.g. Nekkar), the plugin now offers an explicit checkbox to skip the `Center` step and go straight to a blind `SlewToCoordinatesAsync` on the J2000 target. A loud `Notification.ShowWarning` and persistent `WARNING:` status text fire on every skipped run, calling out the two failure modes that plate-solving normally hides (FOV-miss from imprecise mount pointing; ASCOM driver J2000/JNOW epoch misreport — known 10Micron / NYX-101 quirk producing ~8–12 arcmin pattern offset). Off by default; plate-solve remains the recommended path.
- **Mount sync after successful Center step** (Rams — Pegasus NYX-101): once `Center` has plate-solved and parked the scope on the target star, the plugin now calls `telescopeMediator.Sync()` with the J2000 coordinates so the subsequent blind ring slews (which by design cannot plate-solve while defocused) start from a corrected reference point. Mitigates fixed-offset epoch quirks in drivers like NYX-101 and 10Micron. Best-effort: drivers without sync support log a warning and continue.

Plus minor UI polish in the panel (toggle group spacing, fit-to-frame icon).

### Release
- Stable: https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.2.0
- Installer: `NINA.CollimationHelper.SkyWave.2.2.0.9.zip` (SHA256 `4B03705363FBF72416A4DF9622140A5CCC10358608E974629F2EC8D5B129148C`)
- Changelog: https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/blob/main/CHANGELOG.md

Manifest generated with the official `CreateManifest.ps1` from this repo's `tools/` via CI.