### PR TITLE
Update Collimation Helper for SkyWave 2.2.1.9

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -4,7 +4,7 @@
     "Version": {
         "Major": "2",
         "Minor": "2",
-        "Patch": "0",
+        "Patch": "1",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -37,9 +37,9 @@
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.2.0/NINA.CollimationHelper.SkyWave.2.2.0.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.2.1/NINA.CollimationHelper.SkyWave.2.2.1.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "4B03705363FBF72416A4DF9622140A5CCC10358608E974629F2EC8D5B129148C",
+        "Checksum": "3CAD79165527D924894A2D4ECB464D34741842852A91AF4FD6E31DB88BB45C53",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
Update **Collimation Helper for SkyWave** to **v2.2.1** (build 2.2.1.9).

### Release
https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.2.1

### Checksum
ZIP: `NINA.CollimationHelper.SkyWave.2.2.1.9.zip`
SHA256: `3CAD79165527D924894A2D4ECB464D34741842852A91AF4FD6E31DB88BB45C53`

### What's new in 2.2.1
- **Skip solve** now centers the ring on the current mount pointing instead of slewing to the cataloged star coordinates. Field-report follow-up to 2.2.0 from a user (16″ GSO RC, 17×24′ FOV) where a blind re-slew to cataloged J2000 was nudging the already-centered star off-axis and pushing ring positions partially outside the sensor.
- Warning toast and log line reworded for the new contract; run aborts cleanly if the mount is disconnected at this step.
- Default plate-solve + sync path unchanged.

### Build
- Manifest generated by `CreateManifest.ps1` from `isbeorn/nina.plugin.manifests/tools` against the built DLL (`AssemblyVersion 2.2.1.9`) in CI.
- MinimumApplicationVersion: 3.0.0.9001 (unchanged).