### PR TITLE
Update Collimation Helper for SkyWave 2.3.0.9

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -3,8 +3,8 @@
     "Identifier": "b7e3f1a2-9c4d-4e8b-a6f5-1d2c3b4a5e6f",
     "Version": {
         "Major": "2",
-        "Minor": "2",
-        "Patch": "1",
+        "Minor": "3",
+        "Patch": "0",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -37,9 +37,9 @@
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.2.1/NINA.CollimationHelper.SkyWave.2.2.1.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.3.0/NINA.CollimationHelper.SkyWave.2.3.0.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "3CAD79165527D924894A2D4ECB464D34741842852A91AF4FD6E31DB88BB45C53",
+        "Checksum": "FFDB3738D0023BB4CCFE0DC4B3FDA9BB2CE57B6B12C89F050D594B291B03FFC9",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
Update **Collimation Helper for SkyWave** to **v2.3.0** (build 2.3.0.9).

### Release
https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.3.0

### Checksum
ZIP: `NINA.CollimationHelper.SkyWave.2.3.0.9.zip`
SHA256: `FFDB3738D0023BB4CCFE0DC4B3FDA9BB2CE57B6B12C89F050D594B291B03FFC9`

### What's new in 2.3.0
- **"Focus break" toggle** — for users without an electronic autofocuser. When enabled, the automated EAF defocus is replaced by an interactive pause that streams preview-only exposures into the live preview, so the user can defocus a manual focuser by eye and press Continue to start the ring capture. Frames during the break are not saved.
- Explicit toggle control (no fragile EAF auto-detection). Honours Cancel and has a frame-cap safety abort. Default EAF path unchanged.

### Build
- Manifest generated by `CreateManifest.ps1` from `isbeorn/nina.plugin.manifests/tools` against the built DLL (`AssemblyVersion 2.3.0.9`) in CI.
- MinimumApplicationVersion: 3.0.0.9001 (unchanged).