### PR TITLE
Add Maximum Horizon 1.0.2.0 (Beta channel)

### DIFF
--- a/manifests/m/Maximum Horizon/3.0.0/1.0.2.0/manifest.json
+++ b/manifests/m/Maximum Horizon/3.0.0/1.0.2.0/manifest.json
@@ -31,7 +31,7 @@
     "Installer": {
         "URL": "https://github.com/astro-roro/Maximum-Horizon/releases/download/v1.0.2.0/NINA.Plugin.MaximumHorizon.dll",
         "Type": "DLL",
-        "Checksum": "45be4b425e9f62b502b6409796654361a40846676b805a41cca990ffdd39befa",
+        "Checksum": "28cbf3f8b2e0c38585437148c7d98c25ca67967d8005511b03a0b2ee72cca001",
         "ChecksumType": "SHA256"
     },
     "Channel": "Beta"

--- a/manifests/m/Maximum Horizon/3.0.0/1.0.2.0/manifest.json
+++ b/manifests/m/Maximum Horizon/3.0.0/1.0.2.0/manifest.json
@@ -1,0 +1,38 @@
+{
+    "Name": "Maximum Horizon",
+    "Identifier": "B7957C29-EE62-45E8-A918-6FEE3C1F566D",
+    "Version": {
+        "Major": "1",
+        "Minor": "0",
+        "Patch": "2",
+        "Build": "0"
+    },
+    "Author": "Astro With RoRo",
+    "Homepage": "https://github.com/astro-roro/Maximum-Horizon",
+    "Repository": "https://github.com/astro-roro/Maximum-Horizon",
+    "License": "MIT",
+    "LicenseURL": "https://opensource.org/licenses/MIT",
+    "ChangelogURL": "https://github.com/astro-roro/Maximum-Horizon/releases",
+    "Tags": [
+        "Sequencer",
+        "Condition",
+        "Horizon"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "0",
+        "Patch": "0",
+        "Build": "0"
+    },
+    "Descriptions": {
+        "ShortDescription": "Defines maximum altitude constraints to avoid imaging targets blocked by overhead obstructions.",
+        "LongDescription": "Maximum Horizon lets you build horizon profiles manually, import them from CSV, or extract from images so your sequences stop when a target exceeds your custom altitude limit.\r\n\r\n## Use cases\r\n- Apartment balcony or rooftop imaging where the sky is partially blocked overhead\r\n- Backyards with trees, structures, or roof eaves limiting view in certain directions\r\n\r\n## Features\r\n- Multiple named horizon profiles (e.g. \"Home\", \"Remote Site\")\r\n- Manual entry, CSV import, and image-based profile creation\r\n- 'Loop until Maximum Horizon' condition that blocks the sequencer when a target rises above the configured maximum altitude\r\n- Real-time visibility display (current altitude vs. maximum altitude, with profile name and ✓/✗ status)\r\n- Global margin buffer for added safety\r\n- Service interface (IMaximumHorizonService) for integration with planning plugins such as Target Scheduler\r\n\r\nProfile storage: %localappdata%\\NINA\\Plugins\\MaximumHorizon\\Profiles\\"
+    },
+    "Installer": {
+        "URL": "https://github.com/astro-roro/Maximum-Horizon/releases/download/v1.0.2.0/NINA.Plugin.MaximumHorizon.dll",
+        "Type": "DLL",
+        "Checksum": "45be4b425e9f62b502b6409796654361a40846676b805a41cca990ffdd39befa",
+        "ChecksumType": "SHA256"
+    },
+    "Channel": "Beta"
+}


### PR DESCRIPTION
## Summary

First manifest submission for a new plugin, **Maximum Horizon**, targeting the Beta channel.

**What it does:** Lets users define *maximum* altitude constraints (an upper horizon profile) to stop imaging targets blocked by overhead obstructions — apartment balconies, rooftop eaves, trees. Complements NINA's existing custom horizon, which only handles lower limits.

**Author:** @astro-roro
**Source:** https://github.com/astro-roro/Maximum-Horizon
**Release:** https://github.com/astro-roro/Maximum-Horizon/releases/tag/v1.0.2.0
**License:** MIT
**NINA compatibility:** Built against 3.0.0.9001 SDK; loading, UI, condition behavior, and a legacy `.maxalt` → JSON migration step all verified on NINA 3.3 nightly #41.

Submitting to Beta initially — happy to move to Stable once a few users have exercised it via the Plugin Manager.

## Verification

- [x] Manifest validates: `node gather.js` → 267/267 successful, 0 failed
- [x] DLL SHA256 in manifest (`28cbf3f8…a001`) matches the GitHub release asset
- [x] Identifier is a permanent GUID (`B7957C29-EE62-45E8-A918-6FEE3C1F566D`)
- [x] Installer.Type = DLL (single-file release artifact)
- [x] Channel = "Beta"

Thanks for keeping the manifest repo running.
