### PR TITLE
Update Collimation Helper for SkyWave to v2.3.1

### DIFF
--- a/manifests/c/CollimationHelperForSkyWave/manifest.json
+++ b/manifests/c/CollimationHelperForSkyWave/manifest.json
@@ -4,7 +4,7 @@
     "Version": {
         "Major": "2",
         "Minor": "3",
-        "Patch": "0",
+        "Patch": "1",
         "Build": "9"
     },
     "Author": "joergsflow",
@@ -37,9 +37,9 @@
         "AltScreenshotURL": "https://raw.githubusercontent.com/joergs-git/Skywave-Collimation-helper-for-NINA/main/pluginsettings.png"
     },
     "Installer": {
-        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.3.0/NINA.CollimationHelper.SkyWave.2.3.0.9.zip",
+        "URL": "https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/download/v2.3.1/NINA.CollimationHelper.SkyWave.2.3.1.9.zip",
         "Type": "ARCHIVE",
-        "Checksum": "FFDB3738D0023BB4CCFE0DC4B3FDA9BB2CE57B6B12C89F050D594B291B03FFC9",
+        "Checksum": "F513B28579FD9E3DF18B03121752CD345728812D6C1EE45E9ACA257B80E1EAD8",
         "ChecksumType": "SHA256"
     }
 }


### PR DESCRIPTION
Bumps Collimation Helper for SkyWave to v2.3.1 — a patch release fixing an epoch-handling bug in the Skip-solve path.

### What this fixes

When the user enabled "Skip solve" (added in v2.2.0 for sparse-field targets where the local plate-solver can't lock on), the plugin read the mount's live RA/Dec via `TelescopeInfo.RightAscension / .Declination` and wrapped those scalars in `Coordinates(..., Epoch.J2000)`. But those values are raw ASCOM driver-native — typically JNOW for most mounts — not J2000. NINA's `SlewToCoordinatesAsync` then ran a one-way J2000→native precession on the mis-labelled input, so every downstream ring slew landed at `native_pointing + precession_delta` (~10–20 arcmin at typical declinations 26 years past J2000.0).

Reported by a user on a SiTech II controller / 16″ GSO RC with a 17×24′ FOV: with Skip solve on, the first ring slew moved his manually-centered star off-axis and pushed the 80%-of-FOV ring partially outside the sensor. The bug shipped in v2.2.1 (which thought it had fixed the same symptom) and was inherited unchanged by v2.3.0.

### What changed

`SkwPanelVM` now reads `info.Coordinates` (already correctly tagged with the driver's `EquatorialSystem`) and calls `.Transform(Epoch.J2000)` before storing the ring center. The downstream J2000→native precession on each slew now inverts that Transform symmetrically and the mount returns to its starting pointing for the "Center" ring position, with ring offsets applied around it as intended. Both the runtime Skip-solve path and the "Use Mount" panel button (which had the same bug, masked by plate-solve when Skip solve was off) are fixed.

Default behaviour (Skip solve off → `Center` + `Sync`) was already epoch-safe via the existing `Sync` call and is unchanged.

### Verification

- ZIP SHA256 verified against the CI-built `NINA.CollimationHelper.SkyWave.2.3.1.9.zip` at the v2.3.1 release.
- Manifest generated by NINA's `CreateManifest.ps1` from the built DLL — no manual edits.
- Stable release published at https://github.com/joergs-git/Skywave-Collimation-helper-for-NINA/releases/tag/v2.3.1.

Thanks!