### PR TITLE
Add 2-Point Polar Alignment plugin v1.1.0.0

### DIFF
--- a/manifests/2/2-Point Polar Alignment/3.1/1.1.0.0/manifest.json
+++ b/manifests/2/2-Point Polar Alignment/3.1/1.1.0.0/manifest.json
@@ -1,0 +1,37 @@
+{
+  "Name": "2-Point Polar Alignment",
+  "Identifier": "0e9e3e58-42fc-4553-8e6e-aba061af4f54",
+  "Author": "Nir Zonshine",
+  "License": "MIT",
+  "LicenseURL": "https://opensource.org/licenses/MIT",
+  "Homepage": "https://github.com/nirzons/TwoPointPolarAlignment",
+  "Repository": "https://github.com/nirzons/TwoPointPolarAlignment",
+  "ChangelogURL": "https://github.com/nirzons/TwoPointPolarAlignment/blob/main/CHANGELOG.md",
+  "Tags": [
+    "Polar Alignment",
+    "Mount",
+    "Alignment"
+  ],
+  "Version": {
+    "Major": 1,
+    "Minor": 1,
+    "Patch": 0,
+    "Build": 0
+  },
+  "MinimumApplicationVersion": {
+    "Major": 3,
+    "Minor": 1,
+    "Patch": 0,
+    "Build": 0
+  },
+  "Installer": {
+    "URL": "https://github.com/nirzons/TwoPointPolarAlignment/releases/download/v1.1.0.0/TwoPointPolarAlignment-v1.1.0.0.zip",
+    "Type": "ZIP",
+    "Checksum": "0642E3D5261AB199AED6BF99E6E1F8CDBDEE93D1A982FC486042426E7AD62A34",
+    "ChecksumType": "SHA256"
+  },
+  "Descriptions": {
+    "ShortDescription": "Fast polar alignment using home position and a 90° RA rotation",
+    "LongDescription": "A premium, lightweight, and highly accurate polar alignment plugin for N.I.N.A. (Nighttime Imaging 'N' Astronomy). Achieve precision polar alignment within minutes using a rock-solid 3D rotation matrix solver requiring only two plate-solved images and a short 90-degree RA rotation. Features a glassmorphic WPF dashboard, real-time visual alignment prompt cards, ALT/AZ mechanical rotation direction instructions adapted to your hemisphere, rough-finder blind solve fallback recovery, safety slewing guards, and stale measurement dimming. Fully integrated with N.I.N.A.'s profile and sequence models."
+  }
+}

--- a/manifests/2/2-Point Polar Alignment/3.1/1.1.0.0/manifest.json
+++ b/manifests/2/2-Point Polar Alignment/3.1/1.1.0.0/manifest.json
@@ -26,8 +26,8 @@
   },
   "Installer": {
     "URL": "https://github.com/nirzons/TwoPointPolarAlignment/releases/download/v1.1.0.0/TwoPointPolarAlignment-v1.1.0.0.zip",
-    "Type": "ZIP",
-    "Checksum": "0642E3D5261AB199AED6BF99E6E1F8CDBDEE93D1A982FC486042426E7AD62A34",
+    "Type": "ARCHIVE",
+    "Checksum": "E6FB66A3105D51682FD3C2E092798BB48F12F3084F9EED29DBDB95F5FA344EED",
     "ChecksumType": "SHA256"
   },
   "Descriptions": {


### PR DESCRIPTION
This pull request adds the initial official release manifest for the **2-Point Polar Alignment (2PPA)** plugin, version `1.1.0.0`, compatible with N.I.N.A. 3.1+.

- **Plugin Name**: 2-Point Polar Alignment
- **License**: MIT (Open Source)
- **Repository**: https://github.com/nirzons/TwoPointPolarAlignment
- **Installer Checksum (SHA-256)**: `0642E3D5261AB199AED6BF99E6E1F8CDBDEE93D1A982FC486042426E7AD62A34`

Thank you for reviewing!