### PR TITLE
Add Auto Start Sequence 1.1.0

### DIFF
--- a/manifests/a/Auto Start Sequence/1.1.0/manifest.json
+++ b/manifests/a/Auto Start Sequence/1.1.0/manifest.json
@@ -5,7 +5,7 @@
         "Major": "1",
         "Minor": "1",
         "Patch": "0",
-        "Build": "0"
+        "Build": "1"
     },
     "Author": "RegulusRemains",
     "Homepage": "https://github.com/RegulusRemains/nina-auto-start-sequence",
@@ -30,9 +30,9 @@
         "LongDescription": "Auto Start Sequence automatically starts the currently loaded advanced sequence shortly after NINA launches, once your critical equipment has connected. It is built for fully unattended observatories.\r\n\r\nOn startup the plugin waits a short delay for connections to settle, then polls the camera, mount, and safety monitor. Once all three are connected it briefly stabilizes and starts the loaded advanced sequence. If they have not all connected within a maximum wait, it starts the sequence anyway and lets the sequence's own Connect Equipment step recover, so a single slow device never blocks the night. If a sequence is already running, it does nothing.\r\n\r\nA typical unattended flow: the PC wakes on schedule, NINA launches, the plugin starts the sequence, and a Wait for Sun Altitude gate at the top of the sequence holds until dusk.\r\n\r\nThe enable switch and timing (initial delay, maximum wait, poll interval) are configurable on the plugin's Options page and saved per profile.\r\n\r\nProvided under the Mozilla Public License 2.0."
     },
     "Installer": {
-        "URL": "https://github.com/RegulusRemains/nina-auto-start-sequence/releases/download/v1.1.0.0/NINA.Plugin.AutoStartSequence.dll",
+        "URL": "https://github.com/RegulusRemains/nina-auto-start-sequence/releases/download/v1.1.0.1/NINA.Plugin.AutoStartSequence.dll",
         "Type": "DLL",
-        "Checksum": "f085fa1c7c8ded848679446a0786bb9247da13905afd0c90684a64bffaee1fba",
+        "Checksum": "28deee415306e11e2aaac652870ea123a587f9ffa06daff94eace7df7261ff67",
         "ChecksumType": "SHA256"
     }
 }

--- a/manifests/a/Auto Start Sequence/1.1.0/manifest.json
+++ b/manifests/a/Auto Start Sequence/1.1.0/manifest.json
@@ -1,0 +1,38 @@
+{
+    "Name": "Auto Start Sequence",
+    "Identifier": "e5c5edcb-2c3c-492f-99ef-119c0daebd22",
+    "Version": {
+        "Major": "1",
+        "Minor": "1",
+        "Patch": "0",
+        "Build": "0"
+    },
+    "Author": "RegulusRemains",
+    "Homepage": "https://github.com/RegulusRemains/nina-auto-start-sequence",
+    "Repository": "https://github.com/RegulusRemains/nina-auto-start-sequence",
+    "License": "MPL-2.0",
+    "LicenseURL": "https://www.mozilla.org/en-US/MPL/2.0/",
+    "ChangelogURL": "https://github.com/RegulusRemains/nina-auto-start-sequence/blob/main/CHANGELOG.md",
+    "Tags": [
+        "Automation",
+        "Sequence",
+        "AutoStart",
+        "Unattended"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "0",
+        "Patch": "0",
+        "Build": "3001"
+    },
+    "Descriptions": {
+        "ShortDescription": "Automatically starts the loaded advanced sequence when NINA launches, once equipment is connected \u2014 for unattended observatories.",
+        "LongDescription": "Auto Start Sequence automatically starts the currently loaded advanced sequence shortly after NINA launches, once your critical equipment has connected. It is built for fully unattended observatories.\r\n\r\nOn startup the plugin waits a short delay for connections to settle, then polls the camera, mount, and safety monitor. Once all three are connected it briefly stabilizes and starts the loaded advanced sequence. If they have not all connected within a maximum wait, it starts the sequence anyway and lets the sequence's own Connect Equipment step recover, so a single slow device never blocks the night. If a sequence is already running, it does nothing.\r\n\r\nA typical unattended flow: the PC wakes on schedule, NINA launches, the plugin starts the sequence, and a Wait for Sun Altitude gate at the top of the sequence holds until dusk.\r\n\r\nThe enable switch and timing (initial delay, maximum wait, poll interval) are configurable on the plugin's Options page and saved per profile.\r\n\r\nProvided under the Mozilla Public License 2.0."
+    },
+    "Installer": {
+        "URL": "https://github.com/RegulusRemains/nina-auto-start-sequence/releases/download/v1.1.0.0/NINA.Plugin.AutoStartSequence.dll",
+        "Type": "DLL",
+        "Checksum": "f085fa1c7c8ded848679446a0786bb9247da13905afd0c90684a64bffaee1fba",
+        "ChecksumType": "SHA256"
+    }
+}


### PR DESCRIPTION
Adds the manifest for **Auto Start Sequence** 1.1.0.

A small plugin for unattended observatories: when NINA launches it waits for the camera, mount, and safety monitor to connect, then automatically starts the currently loaded advanced sequence. If equipment hasn't all connected within a configurable maximum wait, it starts the sequence anyway (letting the sequence's own Connect Equipment step recover); if a sequence is already running it does nothing. The enable switch and timing (initial delay, max wait, poll interval) are configurable on the plugin's Options page and saved per profile.

- Repository: https://github.com/RegulusRemains/nina-auto-start-sequence
- License: MPL-2.0
- Minimum NINA version: 3.0.0.3001
- Installer: v1.1.0.0 GitHub release DLL; SHA256 in the manifest matches the published asset.

Manifest validated against `manifest.schema.json`.