### PR TITLE
Add Benchmark plugin (0.6.3.0)

### DIFF
--- a/manifests/b/Benchmark/3.2.0.9001/0.6.3.0/manifest.json
+++ b/manifests/b/Benchmark/3.2.0.9001/0.6.3.0/manifest.json
@@ -1,0 +1,41 @@
+{
+    "Name": "Benchmark",
+    "Identifier": "5ebd0d69-a343-472f-b4b6-487a63249448",
+    "Version": {
+        "Major": "0",
+        "Minor": "6",
+        "Patch": "3",
+        "Build": "0"
+    },
+    "Author": "CaeloWorks",
+    "Homepage": "https://nina-benchmark-plugin.com",
+    "Repository": "https://github.com/caelo-works/nina.plugin.benchmark",
+    "License": "MPL-2.0",
+    "LicenseURL": "https://www.mozilla.org/en-US/MPL/2.0/",
+    "ChangelogURL": "https://github.com/caelo-works/nina.plugin.benchmark/releases",
+    "Tags": [
+        "benchmark",
+        "performance",
+        "diagnostics",
+        "imaging"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "2",
+        "Patch": "0",
+        "Build": "0"
+    },
+    "Descriptions": {
+        "ShortDescription": "Benchmarks your machine by timing N.I.N.A.'s real image-analysis primitives (debayer, stretch remap, resize, blur, Canny, SIS threshold, dilation, blob counter, star detection) over a set of test frames it downloads once.",
+        "LongDescription": "This plugin measures how fast your machine runs the genuine N.I.N.A. / Accord image-analysis routines that make up the post-capture pipeline. Each function is invoked exactly the way N.I.N.A. invokes it (same input pixel formats, same constructor arguments, same chain order) over a small set of test frames. The frames are not bundled with the plugin: they are downloaded once from the sharing site (~190 MB), cached locally, and re-verified (sha256) before every run.\n\nMeasured per frame:\n- BayerFilter16bpp: debayering (OSC frames),\n- ColorRemappingGeneral: the auto-stretch pixel remap,\n- FastGaussianBlur: noise reduction,\n- ResizeBicubic: downscale to detection size,\n- CannyEdgeDetector and NoBlurCannyEdgeDetector: edge detection,\n- SISThreshold: thresholding,\n- BinaryDilation3x3: dilation,\n- Convolution: a Laplacian-of-Gaussian kernel pass,\n- BlobCounter: structure/blob detection,\n- StarDetection: the full detector (HFR + star count), shown but excluded from the score as a superset of the primitives.\n\nEach function is timed (one warm-up pass, then the mean of N runs) and aggregated into a per-function breakdown plus an overall score, so you can compare mini-PCs, NUCs and laptops on the real acquisition workload. A system-information panel (CPU, frequency, power plan, GPU, RAM) and the history of the latest runs (with best score and a clear-all action) are available both on the plugin page and as dockables on the Imaging view.",
+        "FeaturedImageURL": "https://nina-benchmark-plugin.com/cpu.png",
+        "ScreenshotURL": "",
+        "AltScreenshotURL": ""
+    },
+    "Installer": {
+        "URL": "https://github.com/caelo-works/nina.plugin.benchmark/releases/download/v0.6.3.0/CaeloWorks.NINA.Benchmark.dll",
+        "Type": "DLL",
+        "Checksum": "8238006CBAECF0E2B279019BD6EB25B993A8A48C36CDDCDB57D4414736854245",
+        "ChecksumType": "SHA256"
+    }
+}


### PR DESCRIPTION
Adds the **Benchmark** plugin (v0.6.3.0).

Times N.I.N.A.'s real image-analysis primitives (debayer, stretch, resize, blur, Canny, SIS threshold, dilation, blob counter, star detection) over a downloadable test set, then scores the machine for comparison and sharing.

- Identifier: `5ebd0d69-a343-472f-b4b6-487a63249448`
- Author: CaeloWorks · License: MPL-2.0
- Repository: https://github.com/caelo-works/nina.plugin.benchmark
- MinimumApplicationVersion: 3.2.0.0
- Installer: GitHub release DLL, SHA256 in the manifest (verified against the asset)

Validated locally with `node gather.js` (manifest valid, 0 invalid).