### PR TITLE
publish plugin for OnStepX mounts

### DIFF
--- a/manifests/o/OnStepXTools/1.0.1.1/manifest.json
+++ b/manifests/o/OnStepXTools/1.0.1.1/manifest.json
@@ -1,0 +1,42 @@
+{
+    "Name": "OnStepX Tools",
+    "Identifier": "3a8f2c10-4b7e-4d6a-9e3f-0c1d5e8f2a4b",
+    "Version": {
+        "Major": "1",
+        "Minor": "0",
+        "Patch": "1",
+        "Build": "1"
+    },
+    "Author": "Michel Moriniaux",
+    "Homepage": "",
+    "Repository": "https://github.com/MichelMoriniaux/NINA.Plugin.OnStepXTools",
+    "License": "MIT",
+    "LicenseURL": "https://opensource.org/licenses/MIT",
+    "ChangelogURL": "https://github.com/MichelMoriniaux/NINA.Plugin.OnStepXTools/commits/main",
+    "Tags": [
+        "OnStepX",
+        "Alignment",
+        "PointingModel",
+        "Telescope",
+        "Mount"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "0",
+        "Patch": "0",
+        "Build": "2017"
+    },
+    "Descriptions": {
+        "ShortDescription": "Mount configuration and automated pointing model generation for OnStepX controllers",
+        "LongDescription": "This plugin provides configuration panels for OnStepX mounts, as well as pointing model generation.\r\n\r\n* NOTE: Use at your own risk this is unproven software, the model is not fully tested at this time *\r\n\r\n# Features #\r\n\r\n* Build full sky models using Golden Spiral in an Imaging tab dock\r\n* Sidereal Path model point generation that creates points along the sidereal path of a DSO\r\n* Grid model point generation that creates points along the AltAz grid\r\n* Random point generation that creates random points in the sky\r\n* Points sequence is optimized to reduce movements and meridian flips\r\n* Advanced Sequencer items to build, load, and save models as part of a sequence\r\n* NINA horizons supported. Load the horizon file in NINA Options -> General\r\n* View and save loaded alignment models\r\n* Load and Delete existing alignment models\r\n* Adjust mount Options as in the SWS\r\n* Adjust motor and PID parameters\r\n\r\n# Support #\r\n\r\nUsually active in the JTW discord as 'Crockett AndTubbs'\r\n",
+        "FeaturedImageURL": "https://github.com/MichelMoriniaux/NINA.Plugin.OnStepXTools/releases/download/resources/OnStepX.jpg",
+        "ScreenshotURL": "https://github.com/MichelMoriniaux/NINA.Plugin.OnStepXTools/releases/download/resources/OnStepXToolsScreenshot.JPG",
+        "AltScreenshotURL": "https://github.com/MichelMoriniaux/NINA.Plugin.OnStepXTools/releases/download/resources/OnStepXToolsAltScreenshot.JPG"
+    },
+    "Installer": {
+        "URL": "https://github.com/MichelMoriniaux/NINA.Plugin.OnStepXTools/releases/download/1.0.1.1/NINA.Plugin.OnStepXTools.zip",
+        "Type": "ARCHIVE",
+        "Checksum": "3371584B5E081AC01F078DCC19D7B52CFE1B63CA478421B95FD021017A679CF7",
+        "ChecksumType": "SHA256"
+    }
+}


### PR DESCRIPTION
the new manifests allows for deployment of the new OnStepX mount control and model builder plugin