### PR TITLE
update subframes to 0.5.4 to address issues with logging

### DIFF
--- a/manifests/s/Subframes/3.1.0/manifest.json
+++ b/manifests/s/Subframes/3.1.0/manifest.json
@@ -3,7 +3,7 @@
   "Identifier": "3ae05d9d-f170-5182-a0c1-75c76a1154f4",
   "Version": {
     "Major": "0",
-    "Minor": "4",
+    "Minor": "5",
     "Patch": "4",
     "Build": "0"
   },
@@ -35,9 +35,9 @@
     "FeaturedImageURL": ""
   },
   "Installer": {
-    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.4.4/SubframesPlugin-v0.4.4.zip",
+    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.5.4/SubframesPlugin-v0.5.4.zip",
     "Type": "ARCHIVE",
-    "Checksum": "29a9857e7875c01ab159ec0f5467924787157b6b6f4c200da85701c7edc4d885",
+    "Checksum": "cf3a07539c7d2571c37b091cdf64bf5366c5abc6e5bd1f356468013c102937ad",
     "ChecksumType": "SHA256"
   }
 }


### PR DESCRIPTION
**Logging Overhaul**
The plugin logging system has been reworked to improve the debug log file behaviour.

**Dedicated debug log file**: When NINA is configured for Debug or Trace logging, the plugin writes a separate log file to the NINA Logs directory containing only Subframes messages. This file is useful for diagnosing plugin-specific issues without sifting through the full NINA log.

**Changes to the debug log file**:

- One file per NINA launch session (e.g. subframes-2026-07-04_223015.log), matching NINA own log file convention. Previously it was date-based, which could create unexpected files on day rollover.
- The plugin dynamically monitors NINA global log level. If the level is changed to Debug mid-session, the log file is created and logging begins. If changed back to Info, file logging stops.
- No file is created or written when NINA is at Info level or higher.
- The log file format is: timestamp | level | message.