### PR TITLE
Add RTSP Timelapse Control 1.4.1

### DIFF
--- a/manifests/r/RTSP Timelapse Control/3.2.0.9001/1.4.1.0/manifest.json
+++ b/manifests/r/RTSP Timelapse Control/3.2.0.9001/1.4.1.0/manifest.json
@@ -1,0 +1,24 @@
+{
+    "Name": "RTSP Timelapse Control",
+    "Identifier": "b3f2c1a4-7d6e-4f9a-9c2b-1e5d8a0f3c47",
+    "Version": { "Major": 1, "Minor": 4, "Patch": 1, "Build": 0 },
+    "Author": "HiranD",
+    "Homepage": "https://github.com/HiranD/RTSP-Timelapse-Capture",
+    "Repository": "https://github.com/HiranD/nina-rtsp-timelapse",
+    "License": "MIT",
+    "LicenseURL": "https://opensource.org/licenses/MIT",
+    "ChangelogURL": "https://github.com/HiranD/nina-rtsp-timelapse/blob/main/CHANGELOG.md",
+    "Tags": ["Timelapse", "RTSP", "Camera", "Automation", "AllSky"],
+    "MinimumApplicationVersion": { "Major": 3, "Minor": 2, "Patch": 0, "Build": 9001 },
+    "Installer": {
+        "URL": "https://github.com/HiranD/nina-rtsp-timelapse/releases/download/v1.4.1/NINA.RtspTimelapse.Plugin.dll",
+        "Type": "DLL",
+        "Checksum": "0FCC9B55E8E281F373C9AE90CD6A809C3A3DC32B065A2E05756EDEF9894D1495",
+        "ChecksumType": "SHA256"
+    },
+    "Descriptions": {
+        "ShortDescription": "Start/stop RTSP timelapse capture and render videos from your N.I.N.A. sequence - the app can auto-upload each finished timelapse to Discord.",
+        "LongDescription": "**RTSP Timelapse Capture** is a free, open-source (MIT) Windows app that turns any RTSP / IP camera (security cams, all-sky cameras, webcams) into a hands-off timelapse studio. This plugin lets N.I.N.A. drive it as part of your imaging sequence.\n\n### What the app does\n- Capture stills from any RTSP stream on a set interval, with rock-solid reconnection (about 5s timestamp accuracy, 100% capture success rate).\n- Smart overnight scheduling with twilight calculations (civil / nautical / astronomical darkness) or manual times, planned across a calendar.\n- One-click MP4 export with presets: frame rate, speed-up, CRF quality and resolution.\n- Auto-create the video after each night's session and auto-post it to a Discord channel.\n- Minimize-to-tray and start-with-Windows for unattended, headless rigs.\n\n### What this plugin adds\nSequencer instructions to **Start Capture**, **Stop Capture** and **Create Timelapse Video**, plus an imaging-tab dock panel showing live capture status. Let N.I.N.A. run your scenery or all-sky timelapse for exactly the duration of your imaging session, then render it automatically. Create Timelapse Video honours the app's Discord settings, so the finished clip can post straight to your Discord channel.\n\n### Get the app\nDownload / docs: **https://github.com/HiranD/RTSP-Timelapse-Capture**\n\nRequires the RTSP Timelapse app running on the **same PC** with the remote control API enabled (Integrations tab). The connection is loopback-only (127.0.0.1), so NINA and the app must share one machine.",
+        "FeaturedImageURL": "https://raw.githubusercontent.com/HiranD/RTSP-Timelapse-Capture/main/assets/icon.png"
+    }
+}


### PR DESCRIPTION
Adds a new plugin: RTSP Timelapse Control (v1.4.1).

This plugin lets N.I.N.A. drive the companion RTSP Timelapse Capture app as part of an imaging sequence: start/stop capture, a scheduled auto-stop at a chosen time (e.g. Nautical Dawn), and render the finished timelapse (optional Discord upload) - plus an imaging-tab dock panel showing live capture status.

About the app it controls:
RTSP Timelapse Capture is a free, open-source (MIT) Windows app that turns any RTSP / IP camera (security cams, all-sky cameras, webcams) into a hands-off timelapse studio:
- Captures stills from any RTSP stream on a set interval, with robust reconnection.
- Smart overnight scheduling with twilight calculations (civil / nautical / astronomical darkness) or manual times.
- One-click MP4 export with presets (frame rate, speed-up, CRF quality, resolution).
- Optional auto-create and auto-post of each night's video to Discord.
App repo: https://github.com/HiranD/RTSP-Timelapse-Capture

The plugin talks to the app over its localhost HTTP API (loopback only), so N.I.N.A. and the app run on the same PC.

Details:
- Author: HiranD
- License: MIT (open source) - https://github.com/HiranD/nina-rtsp-timelapse
- Minimum N.I.N.A. version: 3.2.0.9001
- Installer: bare DLL published as a GitHub release asset (tag v1.4.1); SHA256 in the manifest
- Manifest validates against the schema locally (node gather.js)

Manifest: manifests/r/RTSP Timelapse Control/3.2.0.9001/1.4.1.0/manifest.json
