### PR TITLE
update subframes to 0.6.7

### DIFF
--- a/manifests/s/Subframes/3.1.0/manifest.json
+++ b/manifests/s/Subframes/3.1.0/manifest.json
@@ -3,8 +3,8 @@
   "Identifier": "3ae05d9d-f170-5182-a0c1-75c76a1154f4",
   "Version": {
     "Major": "0",
-    "Minor": "5",
-    "Patch": "4",
+    "Minor": "6",
+    "Patch": "7",
     "Build": "0"
   },
   "Author": "Subframes.io",
@@ -35,9 +35,9 @@
     "FeaturedImageURL": ""
   },
   "Installer": {
-    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.5.4/SubframesPlugin-v0.5.4.zip",
+    "URL": "https://github.com/subframes-astro/nina-plugin/releases/download/v0.6.7/SubframesPlugin-v0.6.7.zip",
     "Type": "ARCHIVE",
-    "Checksum": "cf3a07539c7d2571c37b091cdf64bf5366c5abc6e5bd1f356468013c102937ad",
+    "Checksum": "bd82294701cee9d885786066e23f242274fd6b472af24d34c72ff0b88493bd88",
     "ChecksumType": "SHA256"
   }
 }


### PR DESCRIPTION
**Autofocus Event Card**
The session timeline now includes a detailed autofocus event card. When you select an autofocus event from the timeline, the card displays a point graph showing the HFR (Half-Flux Radius) measurements recorded at each focus position during that run, along with the calculated best focus point.

To view the autofocus card: open a session, go to the Timeline section, and select an autofocus event.

This gives you a clear visual record of how the focuser performed during the night, making it easier to diagnose focus issues and compare results across sessions.