### PR TITLE
Add Lumix (LumixCamera) 1.2.0.0 manifest

### DIFF
--- a/manifests/l/Lumix/3.0.0/1.2.0.0/LumixPlugin.1.2.0.0.manifest.json
+++ b/manifests/l/Lumix/3.0.0/1.2.0.0/LumixPlugin.1.2.0.0.manifest.json
@@ -32,7 +32,7 @@
     "Installer": {
         "URL": "https://github.com/totoantibes/NinaLumixPlugin/releases/download/1.2.0.0/LumixPlugin.1.2.0.0.zip",
         "Type": "ARCHIVE",
-        "Checksum": "A6504286079CDBEF759F2BB293BBDEBCB8A5F48FE6DB0CE098951D476CDCE445",
+        "Checksum": "CEC2E64ACE9C888977E9DCE767837481E490AE106E50AD2D82A1AF29B6C048E7",
         "ChecksumType": "SHA256"
     }
 }

--- a/manifests/l/Lumix/3.0.0/1.2.0.0/LumixPlugin.1.2.0.0.manifest.json
+++ b/manifests/l/Lumix/3.0.0/1.2.0.0/LumixPlugin.1.2.0.0.manifest.json
@@ -1,0 +1,38 @@
+{
+    "Name": "LumixCamera",
+    "Identifier": "8ced010d-15dd-4d0e-b5c5-acb59e2339bc",
+    "Version": {
+        "Major": "1",
+        "Minor": "2",
+        "Patch": "0",
+        "Build": "0"
+    },
+    "Author": "roberthasson",
+    "Homepage": "https://github.com/totoantibes/NinaLumixPlugin",
+    "Repository": "https://github.com/totoantibes/NinaLumixPlugin",
+    "License": "MPL-2.0",
+    "LicenseURL": "https://www.mozilla.org/en-US/MPL/2.0/",
+    "ChangelogURL": "https://github.com/totoantibes/NinaLumixPlugin",
+    "Tags": [
+        "camera lumix native"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "2",
+        "Patch": "0",
+        "Build": "1067"
+    },
+    "Descriptions": {
+        "ShortDescription": "Control Lumix Cameras natively - nightly",
+        "LongDescription": "Lumix native plugin provides a USB direct method to interface with [compatible Lumix cameras](https://av.jpn.support.panasonic.com/support/global/cs/soft/tool/sdk.html).\r\n\r\nThis differs from the ASCOM Driver which interfaces over wifi and http. As the ASCOM driver allows a wider set of cameras it also does not provide a liveview and is rather slow in downloading the RAW images to Nina.\r\n\r\nThe plugin runs in one of two modes, selected in the plugin options:\r\n\r\n* Standard mode (default): uses the public Lumix SDK DLL that ships with the plugin. Exposures are limited to the camera's discrete shutter-speed list, max 60 s (the public SDK cannot do Bulb).\r\n* Extended mode (optional): loads the DLL from a local install of Panasonic's free [LUMIX Tether application](https://av.jpn.support.panasonic.com/support/global/cs/soft/download/d_lumixtether.html) (never bundled) to unlock capabilities the public SDK lacks.\r\n\r\nExtended-mode features:\r\n* Bulb / exposures beyond 60 s (exact durations)\r\n* Sub-second and full-range shutter speeds, snapped to the nearest supported value so the Flat Wizard converges\r\n* Image-quality control: automatically switches the camera to RAW on connect for full-quality colour frames (Prefer JPEG forces JPEG for the RAW-decode workaround). Standard mode cannot change image quality - it only warns if the camera captures JPEG instead of RAW\r\n* Battery information\r\n* Live camera-mode reading, including the C1-C3 custom presets\r\n* Save destination: SD card, directly to the PC (cardless), or both\r\n* A real capture-complete event instead of waiting on the SD-card file\r\n\r\nTo enable extended mode: install LUMIX Tether, close it (it can't share the USB with N.I.N.A.), then tick 'Use LUMIX Tether extended features' in the options and reconnect. The DLL is auto-detected at the default install path, or a custom path can be set.\r\n\r\nThe driver has a list of suported cameras published by [Panasonic](https://av.jpn.support.panasonic.com/support/global/cs/soft/tool/sdk.html)\r\nThe sensor data is derived from the [Digital Camera Database](https://www.digicamdb.com/)\r\n\r\nIf the camera is not recognized by the driver 2 options are possible:\r\n* Override the sensor dimensions from this page.\r\n* leave them to 0 value in that case the default values of 6000x4000 with 5.9 microns pitch will be used.\r\n\r\nThe driver cannot set the exposure-mode dial (A/S/P/M) - that must be set on the camera body. It reads the current mode and warns if not in a manual-capable mode; Manual (M) and the C1-C3 custom presets (assumed M-based) are accepted, other modes warn but do not block.\r\n\r\n# Known Limitations\r\n* Lumix RAW data assume a 14 bit depth. Overriding the bitdepth is also possible from the settings page.\r\n* RAW (.RW2) decoding depends on your N.I.N.A. version. N.I.N.A. 3.3 and later convert RAW with LibRaw, which decodes RW2 directly - no workaround needed. On 3.2 and earlier the legacy DCRaw converter does not support RW2, so set the RAW decoder to FreeImage in the camera advanced settings (Equipment tab). A very recent camera whose RW2 variant your N.I.N.A.'s decoder does not yet recognise (e.g. the GH7) may still show a noisy preview even under LibRaw; enabling Prefer JPEG in the plugin options is a fallback for that case (extended mode only).\r\n* In standard mode Bulb is unavailable, so a requested exposure is snapped to the nearest supported shutter speed (max 60 s). Bulb / >60 s requires extended mode.\r\n\r\n# Getting help\r\n\r\nHelp for this plugin may be found in the **#plugin-discussions** channel on the NINA project [Discord chat server](https://discord.com/invite/rWRbVbw) or by filing an issue report at this plugin's [Github repository](https://github.com/daleghent/nina-plugins/issues).\r\n\r\n* The Plugin is provided 'as is' under the terms of the [Mozilla Public License 2.0](https://github.com/totoantibes/NinaLumixPlugin?tab=MPL-2.0-1-ov-file)\r\n* Source code for this plugin is available in my NINA plugins [source code repository](https://github.com/totoantibes/NinaLumixPlugin)\r\n* THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE",
+        "FeaturedImageURL": "https://photorumors.com/wp-content/uploads/2016/07/Panasonic-Lumix-G-logo.jpg",
+        "ScreenshotURL": "",
+        "AltScreenshotURL": ""
+    },
+    "Installer": {
+        "URL": "https://github.com/totoantibes/NinaLumixPlugin/releases/download/1.2.0.0/LumixPlugin.1.2.0.0.zip",
+        "Type": "ARCHIVE",
+        "Checksum": "A6504286079CDBEF759F2BB293BBDEBCB8A5F48FE6DB0CE098951D476CDCE445",
+        "ChecksumType": "SHA256"
+    }
+}


### PR DESCRIPTION
Adds the manifest for **LumixCamera 1.2.0.0** (plugin identifier `8ced010d-15dd-4d0e-b5c5-acb59e2339bc`, an update of the existing 1.0.0.30 / 1.1.0.30 entries).

Release/source: https://github.com/totoantibes/NinaLumixPlugin/releases/tag/1.2.0.0

What's new in 1.2.0.0: an optional **Extended mode** (loads the DLL from a local Panasonic LUMIX Tether install — never bundled) alongside the existing public-SDK Standard mode. It adds Bulb / exposures beyond 60 s, sub-second and full-range shutter speeds (snapped to the nearest supported value so the Flat Wizard converges), automatic RAW switching on connect, battery info, live camera-mode reading, direct-to-PC (cardless) save, and a real capture-complete event.

- MPL-2.0, source public at the repository above.
- Manifest generated with `tools/CreateManifest.ps1`; `Installer.URL` points at the GitHub release asset and the SHA256 checksum matches the hosted zip.
- Validated locally with `validate-latest-manifest.js` (schema + live checksum) — passes.