### PR TITLE
Update Astrovault plugin (1.1.0.0)

### DIFF
--- a/manifests/a/Astrovault/3.2.0.9001/1.1.0.0/manifest.json
+++ b/manifests/a/Astrovault/3.2.0.9001/1.1.0.0/manifest.json
@@ -1,0 +1,43 @@
+{
+    "Name": "Astrovault",
+    "Identifier": "177b9193-0cec-429c-b9b1-19c776f26fe0",
+    "Version": {
+        "Major": "1",
+        "Minor": "1",
+        "Patch": "0",
+        "Build": "0"
+    },
+    "Author": "AstrosphereHub",
+    "Homepage": "https://vault.astrospherehub.com/",
+    "Repository": "https://github.com/ashanuoc/astrovault-nina-plugin",
+    "License": "MPL-2.0",
+    "LicenseURL": "https://www.mozilla.org/en-US/MPL/2.0/",
+    "ChangelogURL": "",
+    "Tags": [
+        "cloud",
+        " upload",
+        " backup",
+        " sync",
+        " storage",
+        " astrovault"
+    ],
+    "MinimumApplicationVersion": {
+        "Major": "3",
+        "Minor": "2",
+        "Patch": "0",
+        "Build": "9001"
+    },
+    "Descriptions": {
+        "ShortDescription": "Automatically uploads captured astrophotography images to Astrovault cloud storage",
+        "LongDescription": "Astrovault automatically uploads your captured astrophotography images to secure cloud storage.\r\n\r\nFeatures:\r\n- Automatic upload when images are saved\r\n- Persistent queue that survives restarts\r\n- Retry logic with exponential backoff\r\n- Non-blocking uploads (doesn't slow down imaging)\r\n- Storage-quota aware: stops cleanly when your plan is full, shows a persistent notice with a one-click resume, and never loses a frame\r\n- Storage usage display in the plugin options\r\n\r\nConfigure your API endpoint and key in the plugin options.",
+        "FeaturedImageURL": "https://github.com/ashanuoc/astrovault-nina-plugin/releases/download/1.0.0.0/logo.png",
+        "ScreenshotURL": "",
+        "AltScreenshotURL": ""
+    },
+    "Installer": {
+        "URL": "https://github.com/ashanuoc/astrovault-nina-plugin/releases/download/1.1.0.0/Astrovault.1.1.0.0.zip",
+        "Type": "ARCHIVE",
+        "Checksum": "CE683F49B42582BF97060B49D50325B703F66404276F56B240350A9B0AE75CA8",
+        "ChecksumType": "SHA256"
+    }
+}


### PR DESCRIPTION
Astrovault 1.1.0.0 - adds storage-quota handling (clean stop + resume when the account storage plan is full), upload-manager restart fixes, and a storage usage display.